### PR TITLE
Add Jest and buildPdf test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.16",
@@ -29,6 +30,9 @@
     "eslint-config-next": "15.0.3",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.15",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.11"
   }
 }

--- a/tests/buildPdf.test.ts
+++ b/tests/buildPdf.test.ts
@@ -1,0 +1,24 @@
+import { buildPdf } from '@/actions/build-pdf';
+import { ContentItem } from '@/types/pdf/ContentItem';
+import { ContentRendererTypes } from '@/config/pdf-setup';
+
+describe('buildPdf', () => {
+  it('returns success message and data URI', async () => {
+    const items = [
+      new ContentItem({
+        content: {
+          name: 'John Doe',
+          email: 'john@example.com',
+          website: 'example.com',
+          phone: '555-5555',
+          summary: 'Test summary'
+        },
+        rendererKey: ContentRendererTypes.TITLE
+      })
+    ];
+
+    const result = await buildPdf(items, 'Test');
+    expect(result.message).toBe('SUCCESS');
+    expect(result.dataUriString).toMatch(/^data:application\/pdf;base64,/);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest dev dependencies and test script
- configure `jest.config.js`
- add unit test for `buildPdf`

## Testing
- `node ./node_modules/jest/bin/jest.js tests/buildPdf.test.ts` *(fails: Cannot find module '@babel/types')*

------
https://chatgpt.com/codex/tasks/task_e_6843048f88e8832e9b36ddaf4724e58b